### PR TITLE
Add a "header_only" option to the parser.

### DIFF
--- a/http_parser/parser.pyx
+++ b/http_parser/parser.pyx
@@ -114,7 +114,7 @@ cdef int on_headers_complete_cb(http_parser *parser):
         else:
             res.decompress = False
 
-    return 0
+    return res.header_only and 1 or 0
 
 cdef int on_message_begin_cb(http_parser *parser):
     res = <object>parser.data
@@ -142,10 +142,11 @@ cdef int on_message_complete_cb(http_parser *parser):
 
 class _ParserData(object):
 
-    def __init__(self, decompress=False):
+    def __init__(self, decompress=False, header_only=False):
         self.url = ""
         self.body = []
         self.headers = IOrderedDict()
+        self.header_only = header_only
 
         self.decompress = decompress
         self.decompressobj = None
@@ -172,7 +173,7 @@ cdef class HttpParser:
     cdef str _fragment
     cdef object _parsed_url
 
-    def __init__(self, kind=2, decompress=False):
+    def __init__(self, kind=2, decompress=False, header_only=False):
         """ constructor of HttpParser object.
         :
         attr kind: Int,  could be 0 to parseonly requests,
@@ -190,7 +191,7 @@ cdef class HttpParser:
 
         # initialize parser
         http_parser_init(&self._parser, parser_type)
-        self._data = _ParserData(decompress=decompress)
+        self._data = _ParserData(decompress=decompress, header_only=header_only)
         self._parser.data = <void *>self._data
         self._parsed_url = None
         self._path = ""


### PR DESCRIPTION
This option should be set to True when parsing the response to a HEAD method. The HEAD method is special because it has no body even if according to the response headers it has a body.

This patch is necessary when pipelining HEAD requests. The response for a later request could mistakenly be interpreted as being the body to a previous HEAD response.

I have not added the updated parser.c to this pull request, so Travis will likely fail again. I do not think it is possible to have the diffs to parser.c from this pull commute with the diffs from my other pull request. Maybe the setup.py should be updated to regenerate the parser when building.
