### PR TITLE
Handle continuation HTTP headers correctly

### DIFF
--- a/http_parser/parser.pyx
+++ b/http_parser/parser.pyx
@@ -90,9 +90,9 @@ cdef int on_header_value_cb(http_parser *parser, char *at,
     res = <object>parser.data
     header_value = bytes_to_str(PyBytes_FromStringAndSize(at, length))
 
-    if res._last_field in res.headers:
-        header_value = "%s, %s" % (res.headers[res._last_field],
-                header_value)
+    if len(res.headers.get(res._last_field,"")):
+        hsep = " " if res._last_was_value else ", "
+        header_value = hsep.join([res.headers[res._last_field], header_value])
 
         # add to headers
     res.headers[res._last_field] = header_value

--- a/testing/test_headers.py
+++ b/testing/test_headers.py
@@ -1,0 +1,22 @@
+import pytest
+import io
+
+from http_parser.http import HttpStream
+
+
+def test_continuation_header():
+    stream = io.BytesIO(b'GET /test HTTP/1.1\r\nX-Test: foo\r\n bar\r\n\r\n')
+    hdr = HttpStream(stream).headers()
+    assert hdr['X-Test'] == 'foo bar'
+
+def test_repeated_header():
+    stream = io.BytesIO(b'GET /test HTTP/1.1\r\nX-Test: foo\r\nX-Test: bar\r\n\r\n')
+    hdr = HttpStream(stream).headers()
+    assert hdr['X-Test'] == 'foo, bar'
+
+def test_repeated_continuation_header():
+    stream = io.BytesIO(b'GET /test HTTP/1.1\r\nX-Test: foo\r\n bar\r\nX-Test: baz\r\n qux\r\n\r\n')
+    hdr = HttpStream(stream).headers()
+    assert hdr['X-Test'] == 'foo bar, baz qux'
+
+


### PR DESCRIPTION
Currently, `http_parser.parser` joins continued header values together as a comma-separated list. According to the [RFC](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) continuation lines should instead be joined with a single space:

> Any LWS that occurs between field-content MAY be replaced with a single SP before interpreting the field value or forwarding the message downstream.

If a header name is repeated, the values _can_ be folded together into a comma-separated list. The current code handles this correctly.

But in either case, if the header value so far is empty, I don't think we should prepend the separator. So this:

```
X-Test:
X-Test: foo
X-Test: bar
```

Should be equivalent to

```
X-Test: foo, bar
```

Not

```
X-Test: , foo, bar
```

I've also attached a couple test suite functions for the continuation and repeated header cases.
