### PR TITLE
HttpStream.method() only waits method, not status code

### DIFF
--- a/http_parser/http.py
+++ b/http_parser/http.py
@@ -86,6 +86,9 @@ class HttpStream(object):
     def _wait_on_status(self):
         return self._wait_status_line(self.parser.get_status_code)
 
+    def _wait_on_method(self):
+        return self._wait_status_line(self.parser.get_method)
+
     def url(self):
         """ get full url of the request """
         self._wait_on_url()
@@ -125,7 +128,7 @@ class HttpStream(object):
 
     def method(self):
         """ get HTTP method as string"""
-        self._wait_on_status()
+        self._wait_on_method()
         return self.parser.get_method()
 
     def headers(self):


### PR DESCRIPTION
Waiting on the status code for a request required the entire HTTP request to be
read before returning, and also doesn't make sense for a call that only need to
get the method.
