### PR TITLE
Python parser to behave like c parser when no headers in message

### DIFF
--- a/http_parser/pyparser.py
+++ b/http_parser/pyparser.py
@@ -322,6 +322,11 @@ class HttpParser(object):
                 "SERVER_PROTOCOL": bits[2]})
 
     def _parse_headers(self, data):
+        if data == b'\r\n':
+            self.__on_headers_complete = True
+            self.__on_message_begin = True
+            self._buf = []
+            return 0
         idx = data.find(b("\r\n\r\n"))
         if idx < 0: # we don't have all headers
             return False

--- a/http_parser/pyparser.py
+++ b/http_parser/pyparser.py
@@ -222,7 +222,7 @@ class HttpParser(object):
                 try:
                     to_parse = b("").join(self._buf)
                     ret = self._parse_headers(to_parse)
-                    if not ret:
+                    if ret is False:
                         return length
                     nb_parsed = nb_parsed + (len(to_parse) - ret)
                 except InvalidHeader as e:
@@ -324,7 +324,6 @@ class HttpParser(object):
     def _parse_headers(self, data):
         if data == b'\r\n':
             self.__on_headers_complete = True
-            self.__on_message_begin = True
             self._buf = []
             return 0
         idx = data.find(b("\r\n\r\n"))
@@ -402,6 +401,11 @@ class HttpParser(object):
     def _parse_body(self):
         if not self._chunked:
             body_part = b("").join(self._buf)
+            #
+            if not body_part and self._clen is None:
+                if not self._status: # message complete only for servers
+                    self.__on_message_complete = True
+                return
             self._clen_rest -= len(body_part)
 
             # maybe decompress

--- a/testing/test_client.py
+++ b/testing/test_client.py
@@ -1,0 +1,39 @@
+import pytest
+import io
+
+from http_parser.http import HttpStream
+from http_parser.parser import HttpParser
+from http_parser.pyparser import HttpParser as PyHttpParser
+
+def _test_no_headers(parser):
+    data = b'HTTP/1.1 200 Connection established\r\n\r\n'
+    assert parser.execute(data, len(data)) == len(data)
+    assert parser.is_headers_complete()
+    assert parser.is_message_begin()
+    assert not parser.is_partial_body()
+    assert not parser.is_message_complete()
+
+def _test_headers(parser):
+    data = (b'HTTP/1.1 200 OK\r\n'
+            b'Connection: Keep-Alive\r\n'
+            b'Content-Length: 4\r\n'
+            b'Content-type: text/plain\r\n\r\n'
+            b'ciao')
+    assert parser.execute(data, len(data)) == len(data)
+    assert parser.is_headers_complete()
+    assert parser.is_message_begin()
+    assert parser.is_partial_body()
+    assert parser.is_message_complete()
+
+def test_no_headers():
+    _test_no_headers(HttpParser())
+
+def test_no_headers_py():
+    _test_no_headers(PyHttpParser())
+
+def test_headers():
+    _test_headers(HttpParser())
+
+def test_headers_py():
+    _test_headers(PyHttpParser())
+

--- a/testing/test_client.py
+++ b/testing/test_client.py
@@ -25,15 +25,15 @@ def _test_headers(parser):
     assert parser.is_partial_body()
     assert parser.is_message_complete()
 
-def test_no_headers():
+def test_client_no_headers():
     _test_no_headers(HttpParser())
 
-def test_no_headers_py():
+def test_client_no_headers_py():
     _test_no_headers(PyHttpParser())
 
-def test_headers():
+def test_client_headers():
     _test_headers(HttpParser())
 
-def test_headers_py():
+def test_client_headers_py():
     _test_headers(PyHttpParser())
 

--- a/testing/test_server.py
+++ b/testing/test_server.py
@@ -1,0 +1,22 @@
+import pytest
+import io
+
+from http_parser.http import HttpStream
+from http_parser.parser import HttpParser
+from http_parser.pyparser import HttpParser as PyHttpParser
+
+def _test_no_headers(parser):
+    assert not parser.is_headers_complete()
+    data = b'GET /forum/bla?page=1#post1 HTTP/1.1\r\n\r\n'
+    assert parser.execute(data, len(data)), len(data)
+    assert parser.get_fragment(), 'post1'
+    assert parser.is_message_begin()
+    assert parser.is_headers_complete()
+    assert parser.is_message_complete()
+    assert not parser.get_headers()
+
+def test_server_no_headers():
+    _test_no_headers(HttpParser())
+
+def test_server_no_headers_py():
+    _test_no_headers(PyHttpParser())


### PR DESCRIPTION
Just discovered that the python parser does not behave the same way as the c parser when a client receives a message without headers (check the `test_no_headers` below).
Maybe this little fix could do the trick?
