### PR TITLE
Fixes improper parsing for URLs that span multiple chunks.

### DIFF
--- a/http_parser/parser.pyx
+++ b/http_parser/parser.pyx
@@ -75,7 +75,7 @@ cdef extern from "http_parser.h" nogil:
 cdef int on_url_cb(http_parser *parser, char *at,
         size_t length):
     res = <object>parser.data
-    res.url = bytes_to_str(PyBytes_FromStringAndSize(at, length))
+    res.url += bytes_to_str(PyBytes_FromStringAndSize(at, length))
     return 0
 
 cdef int on_header_field_cb(http_parser *parser, char *at,


### PR DESCRIPTION
See https://github.com/benoitc/http-parser/issues/47.
The issue arises because the on_url callback defined in parser.pyx
overwrites url each time it is called. The http_parser c API calls it
for each chunk of the URL, so the proper way is to append instead of
overwriting.
