### PR TITLE
Revert "HttpStream.method() only waits method, not status code"

### DIFF
--- a/http_parser/http.py
+++ b/http_parser/http.py
@@ -87,9 +87,6 @@ class HttpStream(object):
     def _wait_on_status(self):
         return self._wait_status_line(self.parser.get_status_code)
 
-    def _wait_on_method(self):
-        return self._wait_status_line(self.parser.get_method)
-
     def url(self):
         """ get full url of the request """
         self._wait_on_url()
@@ -129,7 +126,7 @@ class HttpStream(object):
 
     def method(self):
         """ get HTTP method as string"""
-        self._wait_on_method()
+        self._wait_on_status()
         return self.parser.get_method()
 
     def headers(self):


### PR DESCRIPTION
This reverts commit 3dc54acc6900d166d09732757dffd7d5588d2b39.

Commit 3dc54acc6900d166d09732757dffd7d5588d2b39 attempts to optimize the parser by waiting only for the method before returning from HttpStream.method(). As implemented, however, this commit breaks parsing of very common requests, as laid out by brosner in the comments of that commit over a year ago.

This pull request simply reverts a commit that clearly breaks request parsing.