### PR TITLE
Fixed python implementation of HttpParser.is_upgrade()

### DIFF
--- a/http_parser/pyparser.py
+++ b/http_parser/pyparser.py
@@ -155,7 +155,7 @@ class HttpParser(object):
     def is_upgrade(self):
         """ Do we get upgrade header in the request. Useful for
         websockets """
-        return self._headers.get('connection', "") == "upgrade"
+        return self._headers.get('connection', "").lower() == "upgrade"
 
     def is_headers_complete(self):
         """ return True if all headers have been parsed. """


### PR DESCRIPTION
Major browsers send `Connection: Upgrade` header for websockets, so current implementation doesn't work. I used `.lower()` to handle every case, since HTTP headers are case-insensitive and we cannot rely on either `Connection: upgrade` or `Connection: Upgrade`