### PR TITLE
Add types dependency.

### DIFF
--- a/http_parser/reader.py
+++ b/http_parser/reader.py
@@ -8,6 +8,7 @@ from io import DEFAULT_BUFFER_SIZE, RawIOBase
 
 from http_parser.util import StringIO
 
+import types
 
 class HttpBodyReader(RawIOBase):
     """ Raw implementation to stream http body """


### PR DESCRIPTION
StringReader depends on the types module for a dependency. Without this fix, any attempt to use the StringReader just fails.
