### PR TITLE
BUG: Not handaling correctly if the header termination is \n\n and not \r\n\r\n

### DIFF
--- a/http_parser/pyparser.py
+++ b/http_parser/pyparser.py
@@ -323,6 +323,8 @@ class HttpParser(object):
 
     def _parse_headers(self, data):
         idx = data.find(b("\r\n\r\n"))
+        if idx < 0:
+            idx = data.find(b("\n\n"))
         if idx < 0: # we don't have all headers
             return False
 


### PR DESCRIPTION
```
From RFC2616 section 19.3 Tolerant Applications: The line terminator for
message-header fields is the sequence CRLF. However, we recommend that
applications, when parsing such headers, recognize a single LF as a line
terminator and ignore the leading CR.
```
