### PR TITLE
Fix parsing of "204 No Content" messages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ nohup.out
 doc/.sass-cache
 http_parser/__pycache__
 MANIFEST
+.pytest_cache/

--- a/testing/test_response.py
+++ b/testing/test_response.py
@@ -1,0 +1,12 @@
+import pytest
+import io
+
+from http_parser.http import HttpStream
+from http_parser.pyparser import HttpParser as PyHttpParser
+
+
+def test_204_no_content():
+    stream = io.BytesIO(b'HTTP/1.1 204 No Content\r\n\r\n')
+    response = HttpStream(stream)
+    assert response.status_code() == 204
+    assert response.body_string() == b''


### PR DESCRIPTION
When parsing a message containing the following content, the
message would never be marked as complete:

`HTTP/1.1 204 No Content\r\n\r\n`