### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - pip install -r requirements_dev.txt
   - python setup.py install
 
-script: py.test testing/
+script: pytest testing/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ python:
   - 2.6
   - 2.7
   - 3.7
-    dist: xenial
-    sudo: true
   - pypy
   - pypy3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - pypy3
 
 install:
-  - pip install -r requirements_dev.txt --use-mirrors
+  - pip install -r requirements_dev.txt
   - python setup.py install
 
 script: py.test testing/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,3 @@ install:
   - python setup.py install
 
 script: py.test testing/
-
-branches:
-  only:
-    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 2.6
   - 2.7
   - 3.7
   - pypy


### PR DESCRIPTION
It was failing for several reasons:

* Fix YAML syntax, sudo not needed and Xenial is now default
* --use-mirrors has been removed from pip
* EOL Python 2.6 no longer available on Travis CI

Also:

* Drop the dot twitter.com/pytestdotorg/status/753767547866972160
* Remove the branch restriction to allow testing feature branches
