### PR TITLE
Require a recent Cython when building C code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+# This file is renamed to "setup.toml.dev" in release tarballs so that
+# Pip won't try to use it.
+
+[build-system]
+# In addition to setuptools and wheel, we need modern Cython, because we are
+# not a packaged release.
+requires = ["setuptools", "wheel", "cython>=0.28.3"]
+

--- a/pyproject.toml.release
+++ b/pyproject.toml.release
@@ -1,0 +1,7 @@
+# This file is renamed to "setup.toml" in release tarballs so that
+# Pip will use it.
+
+[build-system]
+# Release packages only need the standard setuptools and wheel.
+requires = ["setuptools", "wheel"]
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,2 @@
 pytest
-cython
+cython>=0.28.3

--- a/setup.py
+++ b/setup.py
@@ -74,12 +74,16 @@ class sdist(_sdist):
         if os.path.exists('Makefile'):
             make()
             os.rename('Makefile', 'Makefile.ext')
+            os.rename('pyproject.toml', 'pyproject.toml.dev')
+            os.rename('pyproject.toml.release', 'pyproject.toml')
             renamed = True
         try:
             return _sdist.run(self)
         finally:
             if renamed:
                 os.rename('Makefile.ext', 'Makefile')
+                os.rename('pyproject.toml', 'pyproject.toml.release')
+                os.rename('pyproject.toml.dev', 'pyproject.toml')
 
 class BuildFailed(Exception):
     pass


### PR DESCRIPTION
This PR [uses PEP 508](https://www.python.org/dev/peps/pep-0508/) to make sure that a recent Cython is installed when the Makefile is going to run and rebuild the C code. This should fix issues with installing from Git when an old Cython or no Cython is available.