### PR TITLE
Remove unused Feature, since it's been removed from upstream setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import shutil
 import sys
 import traceback
 
-from setuptools import setup, find_packages, Extension, Feature
+from setuptools import setup, find_packages, Extension
 
 if not hasattr(sys, 'version_info') or \
         sys.version_info < (2, 6, 0, 'final'):


### PR DESCRIPTION
The setuptools project has [removed the `Feature` feature](pypa/setuptools#1979), so trying to import it in `setup.py` fails, and causes [cascading failures for any project that installs this package](https://circleci.com/gh/StackStorm-Exchange/stackstorm-kubernetes/479):

```
Collecting http_parser (from -r /home/circleci/repo/requirements.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/07/c4/22e3c76c2313c26dd5f84f1205b916ff38ea951aab0c4544b6e2f5920d64/http-parser-0.8.3.tar.gz (83kB)

    100% |████████████████████████████████| 92kB 13.7MB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-m_29wrbf/http-parser/setup.py", line 19, in <module>
        from setuptools import setup, find_packages, Extension, Feature
    ImportError: cannot import name 'Feature'
```

This PR removes the `Feature` import. I'm not sure why it was [added to begin with](https://github.com/benoitc/http-parser/commit/23c74fe0b3387617c64bb483cb49811997ef76f7#diff-2eeaed663bd0d25b7e608891384b7298R17), since it was never actually ever used anywhere.

Related: pypa/setuptools#2017

@benoitc Additionally, is there any way we can get a version uploaded to PyPI? The last version on PyPI is from Aug 30, 2013, and there have been substantial improvements since then.