### PR TITLE
Switch to importlib in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ from distutils.errors import CCompilerError, DistutilsExecError, \
 from distutils.command.build_ext import build_ext
 from distutils.command.sdist import sdist as _sdist
 import glob
-from imp import load_source
+import importlib.machinery
+import importlib.util
 import io
 import os
 import shutil
@@ -27,6 +28,16 @@ if sys.platform == 'win32' and sys.version_info > (2, 6):
    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
    # find the compiler
    ext_errors += (IOError,)
+
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(
+        modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
 
 http_parser = load_source("http_parser", os.path.join("http_parser",
         "__init__.py"))


### PR DESCRIPTION
The imp module has been deprecated and was removed in Python 3.12. Switch to using importlib functions to load the module, rather than imp.load_source().

Fixes #99